### PR TITLE
📚 Document async support

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ The core of Blinker is quite small but provides powerful features:
  - sending arbitrary data payloads
  - collecting return values from signal receivers
  - thread safety
+ - coroutines as signal receivers
 
 Blinker was written by Jason Kirtand and is provided under the MIT
 License. The library supports Python 2.7 and Python 3.5 or later;
@@ -92,6 +93,32 @@ connected to ``complete`` yet, and that's a-ok.  Calling
 :meth:`~Signal.send` on a signal with no receivers will result in no
 notifications being sent, and these no-op sends are optimized to be as
 inexpensive as possible.
+
+
+Async support
+-------------
+
+Send a signal asynchronously to coroutine receivers.
+
+  >>> async def receiver_a(sender):
+  ...     return 'value a'
+  ...
+  >>> async def receiver_b(sender):
+  ...     return 'value b'
+  ...
+  >>> ready = signal('ready')
+  >>> ready.connect(receiver_a)
+  >>> ready.connect(receiver_b)
+  ...
+  >>> async def collect():
+  ...     return ready.send_async('sender')
+  ...
+  >>> loop = asyncio.get_event_loop()
+  >>> results = loop.run_until_complete(collect())
+  >>> len(results)
+  2
+  >>> [v.result() for r, v in results][0]
+  value a
 
 
 Subscribing to Specific Senders


### PR DESCRIPTION
- Install [sphinx](https://www.sphinx-doc.org/en/master/usage/installation.html). I used the `pip` way rather than `brew`
- Install documentation theme (venv recommended)
- Generate the doc
- Run local webserver

```
$ pip install Flask-Sphinx-Themes
$ make docs
$ python3 -m http.server --directory docs/html
```